### PR TITLE
feat: Implement 30-minute caching for visit plans and analytics

### DIFF
--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -1,0 +1,61 @@
+// src/utils/cache.js
+
+const CACHE_DURATION_MS = 30 * 60 * 1000; // 30 minutes
+const cache = new Map();
+
+/**
+ * Stores data in the cache with a timestamp.
+ * @param {string} key - The cache key.
+ * @param {any} data - The data to store.
+ */
+export const setCache = (key, data) => {
+  const timestamp = Date.now();
+  cache.set(key, { data, timestamp });
+  console.log(`[Cache] Set data for key: ${key}`);
+};
+
+/**
+ * Retrieves data from the cache if it exists and is not older than CACHE_DURATION_MS.
+ * @param {string} key - The cache key.
+ * @returns {any|null} The cached data or null if not found or expired.
+ */
+export const getCache = (key) => {
+  const cachedItem = cache.get(key);
+
+  if (!cachedItem) {
+    console.log(`[Cache] Miss for key: ${key}`);
+    return null;
+  }
+
+  const isExpired = (Date.now() - cachedItem.timestamp) > CACHE_DURATION_MS;
+
+  if (isExpired) {
+    console.log(`[Cache] Expired data for key: ${key}`);
+    cache.delete(key); // Remove expired item
+    return null;
+  }
+
+  console.log(`[Cache] Hit for key: ${key}`);
+  return cachedItem.data;
+};
+
+/**
+ * Clears the entire cache.
+ */
+export const clearCache = () => {
+  cache.clear();
+  console.log('[Cache] Cleared all cache entries.');
+};
+
+/**
+ * Deletes a specific entry from the cache.
+ * @param {string} key - The cache key to delete.
+ */
+export const deleteCacheEntry = (key) => {
+  if (cache.has(key)) {
+    cache.delete(key);
+    console.log(`[Cache] Deleted entry for key: ${key}`);
+  } else {
+    console.log(`[Cache] No entry found to delete for key: ${key}`);
+  }
+};


### PR DESCRIPTION
Introduces a caching mechanism to store and retrieve visit planner and analytics data, reducing redundant data fetching for MRs if data has been accessed within the last 30 minutes.

Key changes:
- Created `src/utils/cache.js`: A simple in-memory cache utility with `setCache`, `getCache`, `clearCache`, and `deleteCacheEntry` functions. Cached items expire after 30 minutes.
- Integrated caching into `src/visitplannerdata.js` (`ReactVisitPlannerML.generateVisitPlan`):
    - Checks for a valid cached visit plan before generating a new one.
    - Stores successfully generated plans in the cache, keyed by MR name, month, and year.
- Integrated caching into `src/visitPlanner/VisitAnalyticsEngine.js` (`VisitAnalyticsEngine.generateAnalytics`):
    - Checks for valid cached analytics data before fetching and processing.
    - Stores successfully generated analytics in the cache, keyed by MR name and timeframe.
    - Includes error handling for AI insight generation to allow caching of main analytics data even if AI insights fail.

This change aims to improve performance and reduce API load by leveraging cached data for recently accessed visit plans and analytics sections.