### PR TITLE
Fix: Ensure existing loading spinner persists until overview data is …

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -683,7 +683,7 @@ const AyurvedicDashboard = () => {
   };
 
   // Loading state
-  if (loading && !isAuthenticated) {
+  if (loading) { // Changed condition here
     return (
       <div className="flex justify-center items-center min-h-screen">
         <div className="text-center">


### PR DESCRIPTION
…loaded

The overview page was displaying before its data was fully loaded, leading to a 3-5 second delay where no data was visible.

This commit modifies the `AyurvedicDashboard` component in `src/App.js` to ensure that its content (including the overview page) is only rendered after the initial data loading is complete (`loading` state is false). This leverages the existing global loading spinner, which is now displayed until all necessary data is fetched, preventing you from seeing an empty overview page.